### PR TITLE
Feat/cs/support search history tape

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For more details, see [Sample Usage Session](docs/README.md#sample-usage-session
 | `/` | regex search |
 | `h` | if regex active, toggle highlighting of matches |
 | `i` | toggle insert mode (default off) |
+| `s` | swap reading `stdin` and `stdout` |
 | `p` | activate parser |
 | `a` | toggle analytics mode when parser is active |
 | `z` | deactivate parser |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There are a few main ways to invoke Logria:
 - With args:
   - `logria -e 'tail -f log.txt'`
   - Opens a pipe to 'tail -f log.txt'` and skips setup
-  - `logria -h` will show the help page with all possible options.
+  - `logria -h` will show the help page with all possible options
 
 For more details, see [Sample Usage Session](docs/README.md#sample-usage-session).
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,6 +6,9 @@
 | `:q` | exit the program |
 | `:poll #` | update [poll rate](#poll-rate) to #, where # is a number |
 | `:config` | enter configuration mode to create sessions or patterns |
+| `:history` | view and search the history tape |
+| `:history #` | view and search the history tape's last # (integer) items |
+| `:history off` | go back to the main app from history mode |
 
 ## Notes
 

--- a/logria/__main__.py
+++ b/logria/__main__.py
@@ -27,7 +27,7 @@ def main():
                             version=f'{APP_NAME} {VERSION}')
         parser.add_argument('-e', action='append', type=str,
                             help='Command to pass through that will stream into this program, ex: logria -e \'tail -f log.txt\'')
-        parser.add_argument('--no-cache', dest='no_cache', default=False, action='store_true',
+        parser.add_argument('--no-cache', dest='no_cache', default=True, action='store_false',
                             help='Disable command history disk cache')
 
         args = parser.parse_args()

--- a/logria/communication/input_history.py
+++ b/logria/communication/input_history.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 from typing import List
 
-from logria.utilities.constants import HISTORY_TAPE_NAME, SAVED_HISTORY_PATH
+from logria.utilities.constants import HISTORY_TAPE_NAME, SAVED_HISTORY_PATH, HISTORY_EXCLUDES
 
 
 class HistoryTape():
@@ -96,12 +96,13 @@ class HistoryTape():
         """
         Adds `item` to the end of the queue and update the index
         """
-        if not self.history_tape or item != self.history_tape[-1]:
-            if self.use_cache:
-                self.write_to_history_file(item)
-            self.history_tape.append(item)
-            self.current_index = len(self.history_tape) - 1
-            self.should_scroll_back = False
+        if item not in HISTORY_EXCLUDES:
+            if not self.history_tape or item != self.history_tape[-1]:
+                if self.use_cache:
+                    self.write_to_history_file(item)
+                self.history_tape.append(item)
+                self.current_index = len(self.history_tape) - 1
+                self.should_scroll_back = False
 
     def scroll_back_n(self, num_to_scroll: int) -> str:
         """

--- a/logria/utilities/constants.py
+++ b/logria/utilities/constants.py
@@ -18,6 +18,12 @@ SAVED_HISTORY_PATH = f'{USER_HOME}/{LOGRIA_ROOT}/history'
 # Filenames
 HISTORY_TAPE_NAME = 'tape'
 
+# Text to exclude from message history
+HISTORY_EXCLUDES = {
+    ':history',
+    ':history off'
+}
+
 # Messages
 START_MESSAGE = [
     'Enter a new command to open and save a new stream,',

--- a/tests/test_history_tape.py
+++ b/tests/test_history_tape.py
@@ -42,6 +42,15 @@ class TestHistoryTapeFunctions(unittest.TestCase):
         tape.add_item('Test')
         self.assertEqual(tape.get_current_item(), 'Test')
 
+    def test_cant_add_excluded_item(self):
+        """
+        Test that we can add and retrieve the current item
+        """
+        tape = input_history.HistoryTape(use_cache=False)
+        tape.add_item(':history')
+        tape.add_item(':history off')
+        self.assertEqual(tape.size(), 0)
+
     def test_at_end(self):
         """
         Test that we correctly report when we are at the end


### PR DESCRIPTION
- Implement #74 
- Support excluding certain messages from the history tape
- Fix bug in `reset_parser()` where we don't reset the `stuck_to_top` property