### PR TITLE
Feat/cs/ignore some files

### DIFF
--- a/logria/commands/parser.py
+++ b/logria/commands/parser.py
@@ -67,12 +67,15 @@ def setup_parser(logria: 'Logria'):  # type: ignore
         logria.activate_prompt()
         command = logria.box.gather().strip()
         if command == ':q':
+            logria.messages = logria.previous_messages
             parser = None
             break
         try:
             parser = Parser()
             parser.load(Parser().patterns()[int(command)])
             break
+        except KeyError:
+            continue
         except JSONDecodeError as err:
             logria.messages.append(
                 f'Invalid JSON: {err.msg} on line {err.lineno}, char {err.colno}')
@@ -90,8 +93,10 @@ def setup_parser(logria: 'Logria'):  # type: ignore
             logria.activate_prompt()
             command = logria.box.gather().strip()
             if command == ':q':
+                logria.messages = logria.previous_messages
+                logria.previous_render = None
                 reset_parser(logria)
-                break
+                return  # no need to do any other work
             try:
                 command = int(command)
                 assert command < len(logria.messages)
@@ -109,6 +114,7 @@ def setup_parser(logria: 'Logria'):  # type: ignore
         # Put pointer back to new list
         logria.messages = logria.parsed_messages
     else:
+        logria.messages = logria.previous_messages
         reset_parser(logria)
 
     # Render immediately

--- a/logria/logger/parser.py
+++ b/logria/logger/parser.py
@@ -9,6 +9,7 @@ from collections import Counter
 from pathlib import Path
 from typing import List, Union
 
+from logria.utilities import fs
 from logria.utilities.constants import ANSI_COLOR_PATTERN, SAVED_PATTERNS_PATH
 
 
@@ -227,7 +228,7 @@ class Parser():
         # Convert to json
         if self._pattern is not None:
             raise ValueError('Setting pattern while pattern already set!')
-        patterns = set(os.listdir(self.folder))
+        patterns = set(fs.listdir(self.folder, {'.DS_Store'}))
         if name in patterns:
             with open(self.folder / name, 'r') as f:
                 d = json.loads(f.read())
@@ -249,12 +250,12 @@ class Parser():
         """
         Get the existing patterns as a dict
         """
-        patterns = os.listdir(self.folder)
+        patterns = fs.listdir(self.folder, {'.DS_Store'})
         return dict(zip(range(0, len(patterns)), patterns))
 
     def show_patterns(self) -> List[str]:
         """
         Get the existing patterns as a list
         """
-        patterns = os.listdir(self.folder)
+        patterns = fs.listdir(self.folder, {'.DS_Store'})
         return [f'{i}: {v}' for i, v in enumerate(patterns)]

--- a/logria/utilities/command_parser.py
+++ b/logria/utilities/command_parser.py
@@ -42,6 +42,7 @@ class Resolver():
                             f'{path} listed in PATH environment variable, refers to file!')
                         continue
                 try:
+                    # No need to use fs wrapper here
                     programs = os.listdir(self.resolve_home_dir(path))
                 except FileNotFoundError:
                     print(

--- a/logria/utilities/fs.py
+++ b/logria/utilities/fs.py
@@ -1,0 +1,15 @@
+"""
+Filesystem interaction functions
+"""
+
+
+import os
+from pathlib import Path
+from typing import Union
+
+
+def listdir(path: Union[str, Path], ignored_patterns: set):
+    """
+    os.listdir wrapper that ignores patterns
+    """
+    return [x for x in os.listdir(path) if x not in ignored_patterns]

--- a/logria/utilities/session.py
+++ b/logria/utilities/session.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from typing import List, Union
 
+from logria.utilities import fs
 from logria.utilities.constants import LOGRIA_ROOT, SAVED_SESSIONS_PATH
 
 
@@ -102,12 +103,12 @@ class SessionHandler():
         """
         Get the existing sessions as a dict
         """
-        sessions = sorted(os.listdir(self.folder))
+        sessions = sorted(fs.listdir(self.folder, {'.DS_Store'}))
         return dict(zip(range(0, len(sessions)), sessions))
 
     def show_sessions(self) -> List[str]:
         """
         Get the existing sessions as a list for output
         """
-        sessions = sorted(os.listdir(self.folder))
+        sessions = sorted(fs.listdir(self.folder, {'.DS_Store'}))
         return [f'{i}: {v}' for i, v in enumerate(sessions)]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -36,8 +36,11 @@ class TestSessionHandler(unittest.TestCase):
         """
         s = session.SessionHandler()
         actual = s.sessions()
-        expected = {0: '.DS_Store', 1: 'Cmd - Generate Test Logs',
-                    2: 'File - Sample Access Log', 3: 'File - readme'}
+        expected = {
+            0: 'Cmd - Generate Test Logs',
+            1: 'File - Sample Access Log',
+            2: 'File - readme'
+        }
         self.assertEqual(actual, expected)
 
     def test_show_sessions(self):
@@ -46,10 +49,9 @@ class TestSessionHandler(unittest.TestCase):
         """
         s = session.SessionHandler()
         actual = s.show_sessions()
-        expected = ['0: .DS_Store',
-                    '1: Cmd - Generate Test Logs',
-                    '2: File - Sample Access Log',
-                    '3: File - readme'
+        expected = ['0: Cmd - Generate Test Logs',
+                    '1: File - Sample Access Log',
+                    '2: File - readme'
                     ]
         self.assertEqual(actual, expected)
 
@@ -68,7 +70,7 @@ class TestSessionHandler(unittest.TestCase):
         """
         s = session.SessionHandler()
         sessions = s.sessions()
-        first_item = list(sessions.keys())[1]
+        first_item = list(sessions.keys())[0]
         actual = s.load_session(first_item)
         expected = \
             {


### PR DESCRIPTION
- Fix #115 by implementing listdir() that ignores some patterns
- Fix crash when user enters a parser index that does not exist