### PR TITLE
Release/0.9.10

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,7 +9,8 @@
 | `:history` | view and search the history tape |
 | `:history #` | view and search the history tape's last # (integer) items |
 | `:history off` | go back to the main app from history mode |
-| `:r #` | When launching logria or viewing sessions, this will delete item # |
+| `:r #` | when launching logria or viewing sessions, this will delete item # |
+| `:restart` | go back to the setup screen to change sessions |
 
 ## Notes
 

--- a/logria/__init__.py
+++ b/logria/__init__.py
@@ -2,4 +2,4 @@
 App name and version
 """
 APP_NAME = 'Logria'
-VERSION = '0.9.9'
+VERSION = '0.9.10'

--- a/logria/commands/command.py
+++ b/logria/commands/command.py
@@ -6,6 +6,7 @@ import curses
 from logria.commands.parser import reset_parser
 from logria.utilities import constants
 from logria.commands.config import config_mode
+from logria.communication.setup import setup_streams
 
 # from logria.communication.shell_output import Logria
 
@@ -59,5 +60,12 @@ def handle_command(logria: 'Logria') -> None:  # type: ignore
                 except ValueError:
                     num_to_get = logria.height  # Default to screen height if no info given
                 start_history_mode(logria, num_to_get)
+        elif command[:8] == ':restart':
+            # Kill all streams
+            for stream in logria.streams:
+                stream.exit()
+            # Remove them from Logria
+            logria.streams = []
+            setup_streams(logria)
     logria.reset_command_line()
     logria.write_to_command_line(logria.current_status)

--- a/logria/communication/input_handler.py
+++ b/logria/communication/input_handler.py
@@ -46,7 +46,8 @@ class InputStream():
         """
         Kills the process
         """
-        self.process.terminate()
+        if self.process:
+            self.process.terminate()
 
 
 class CommandInputStream(InputStream):
@@ -107,7 +108,8 @@ class CommandInputStream(InputStream):
             # Proc may be dead already when we get here
             self.proc.kill()  # Kill piped process
             self.proc.communicate()  # Make sure any final data is not left in the pipe
-        self.process.terminate()  # Kill Python process
+        if self.process:
+            self.process.terminate()  # Kill Python process
 
 
 class FileInputStream(InputStream):

--- a/logria/communication/shell_output.py
+++ b/logria/communication/shell_output.py
@@ -247,8 +247,13 @@ class Logria():
         Resize curses elements when window size changes
         """
         self.height, self.width = self.stdscr.getmaxyx()
-        curses.resizeterm(self.height, self.width)
+        self.width -= 1  # Leave space for padding on the right
+        self.last_row = self.height - 3  # The last row we can write to
+        curses.resizeterm(self.height, self.width + 1)
         self.build_command_line()  # Rebuild the command line
+        # Re-reate the window with these sizes
+        self.outwin = curses.newwin(
+            self.height - 3, self.width, 0, 0)
         self.redraw()
 
     def start(self) -> None:


### PR DESCRIPTION
- Fix bug where window resize only resized the command line and not the output window
- Add `:restart` to send users back to the startup screen without re-launching the app